### PR TITLE
SARIF upload example with GitHub Advanced Security

### DIFF
--- a/services/submission/Dockerfile
+++ b/services/submission/Dockerfile
@@ -32,7 +32,7 @@ RUN ${WORK_DIR}/mvnw --batch-mode -P docker-image --file ${WORK_DIR}/pom.xml ${M
 RUN cp ${WORK_DIR}/services/${SERVICE}/target/*.jar /usr/sap/${SERVICE}-service/service.jar
 RUN cp ${WORK_DIR}/scripts/DpkgHelper.java /DpkgHelper.java
 
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java-debian9:11
 
 ARG SERVICE=submission
 


### PR DESCRIPTION
* Use  java-debian9:11 for Corona warn app submission service
* Show that GitHub Advanced Security can be used to upload security findings of any tool that supports the SARIF format